### PR TITLE
Drop support for Twig 1 and add Twig 3 support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         }
     },
     "require": {
-        "twig/twig": "^1.34.3|^2.4"
+        "twig/twig": "^2.7|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4"
+        "phpunit/phpunit": "^9.5"
     }
 }

--- a/src/EvalNode.php
+++ b/src/EvalNode.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace jæm3l\Twig;
 
+use Twig\Compiler;
 use Twig\Node\Node;
 
 class EvalNode extends Node
 {
-    public function compile(\Twig_Compiler $compiler): void
+    public function compile(Compiler $compiler): void
     {
-        $code = array_reduce($this->nodes, function(string $code, \Twig_Node $node) {
+        $code = array_reduce($this->nodes, function(string $code, Node $node) {
             return $code . $node->getAttribute('data');
         }, '');
 

--- a/src/EvalTokenParser.php
+++ b/src/EvalTokenParser.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace jæm3l\Twig;
 
+use Twig\Token;
 use Twig\TokenParser\AbstractTokenParser;
 
 class EvalTokenParser extends AbstractTokenParser
 {
-    public function parse(\Twig_Token $token)
+    public function parse(Token $token)
     {
         $stream = $this->parser->getStream();
 
-        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
         $content = $this->parser->subparse([$this, 'decideEvalEnd'], true);
-        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+        $stream->expect(Token::BLOCK_END_TYPE);
 
         return new EvalNode([$content], [], $token->getLine(), $this->getTag());
     }
 
-    public function decideEvalEnd(\Twig_Token $token): bool
+    public function decideEvalEnd(Token $token): bool
     {
         return $token->test('endeval');
     }


### PR DESCRIPTION
I got annoyed by my Dependabot alert-emails about the possible security issue with Twig < 2.7, so I figured we can either archive this great library or I update it.